### PR TITLE
Allow configuring the simc executable to use via settings

### DIFF
--- a/bloodytrinkets.py
+++ b/bloodytrinkets.py
@@ -28,7 +28,7 @@ import lib.trinkets
 ## @return     The dps s.
 ##
 def get_dps(trinket_id, item_level, fight_style):
-  argument = "../simc.exe "
+  argument = settings.simc_settings["simc"] + " "
   argument += "iterations=" + settings.simc_settings["iterations"] + " "
   argument += "target_error=" + settings.simc_settings["target_error"] + " "
   argument += "fight_style=" + fight_style + " "

--- a/settings.py
+++ b/settings.py
@@ -28,6 +28,7 @@ output_screen = False
 output_types = ["json", "highchart"]
 
 simc_settings = {}
+simc_settings["simc"] = "../simc.exe"
 simc_settings["fight_styles"] = ["patchwerk", "helterskelter"]
 simc_settings["iterations"]   = "250000"
 simc_settings["target_error"] = "0.1"


### PR DESCRIPTION
I run simulations from Linux and naturally `simc.exe` isn't there,
nor is it necessarily a directory up from the repository root.